### PR TITLE
Support non-collection top-level attributes.

### DIFF
--- a/lib/puppet-swagger-generator/files/swagger/fuzzy_compare.rb
+++ b/lib/puppet-swagger-generator/files/swagger/fuzzy_compare.rb
@@ -9,7 +9,7 @@ module PuppetX
         def self.fuzzy_compare(existing, intended)
           normalized_is = existing.symbolize_keys.fixnumify
           normalized_should = intended.symbolize_keys.fixnumify
-          if normalized_is.all? { |k,v| v.class == String }
+          if normalized_is.respond_to? :all? and normalized_is.all? { |k,v| v.class == String }
             diff = normalized_is.merge(normalized_should)
             diff == normalized_is
           elsif normalized_is == normalized_should


### PR DESCRIPTION
For example: kubernetes_secret.type

metadata:
  name: mysecret
type: Opaque
  data:
    password: dmFsdWUtMg0K
    username: dmFsdWUtMQ0K