### PR TITLE
Use require_relative for local requires.

### DIFF
--- a/lib/puppet-swagger-generator/files/swagger/fuzzy_compare.rb
+++ b/lib/puppet-swagger-generator/files/swagger/fuzzy_compare.rb
@@ -1,5 +1,5 @@
-require 'puppet_x/puppetlabs/swagger/symbolize_keys'
-require 'puppet_x/puppetlabs/swagger/fixnumify'
+require_relative 'symbolize_keys'
+require_relative 'fixnumify'
 
 
 module PuppetX

--- a/lib/puppet-swagger-generator/files/swagger/provider.rb
+++ b/lib/puppet-swagger-generator/files/swagger/provider.rb
@@ -1,4 +1,4 @@
-require 'puppet_x/puppetlabs/swagger/prefetch_error'
+require_relative 'prefetch_error'
 
 module PuppetX
   module Puppetlabs

--- a/lib/puppet-swagger-generator/templates/provider.erb
+++ b/lib/puppet-swagger-generator/templates/provider.erb
@@ -2,7 +2,7 @@
 # any manual changes are likely to be clobbered when the files
 # are regenerated.
 
-require 'puppet_x/puppetlabs/<%= namespace %>/provider'
+require_relative '../../../puppet_x/puppetlabs/<%= namespace %>/provider'
 
 Puppet::Type.type(:<%= namespace %>_<%= name %>).provide(:swagger, :parent => PuppetX::Puppetlabs::<%= namespace.capitalize %>::Provider) do
 

--- a/lib/puppet-swagger-generator/templates/type.erb
+++ b/lib/puppet-swagger-generator/templates/type.erb
@@ -2,7 +2,7 @@
 # any manual changes are likely to be clobbered when the files
 # are regenerated.
 
-require 'puppet_x/puppetlabs/swagger/fuzzy_compare'
+require_relative '../../puppet_x/puppetlabs/swagger/fuzzy_compare'
 
 
 Puppet::Type.newtype(:<%= namespace %>_<%= name %>) do


### PR DESCRIPTION
It appears Puppet Server 4.3 works with it and is able to generate a
catalog.

Based on the approach of https://github.com/puppetlabs/puppetlabs-aws