### PR TITLE
Fix the required properties declaration

### DIFF
--- a/lib/puppet-swagger-generator/templates/type.erb
+++ b/lib/puppet-swagger-generator/templates/type.erb
@@ -16,7 +16,7 @@ Puppet::Type.newtype(:<%= namespace %>_<%= name %>) do
   validate do
     required_properties = [
     <% model['required'].each do |property| %>
-      <%= property.swagger_to_snake_case.to_sym %>,
+      :<%= property.swagger_to_snake_case.to_sym %>,
     <% end %>
     ]
     required_properties.each do |property|


### PR DESCRIPTION
When using kubernetes puppet resources with required properties, I had this error message:
`Error: Failed to apply catalog: undefined local variable or method 'rules' for #<Puppet::Type::Kubernetes_cluster_role:0x00000006fd27e8>`

This fix should do it.
