### PR TITLE
Make sure fuzzy_compare compares all array elements

### DIFF
--- a/lib/puppet-swagger-generator/files/swagger/fuzzy_compare.rb
+++ b/lib/puppet-swagger-generator/files/swagger/fuzzy_compare.rb
@@ -9,42 +9,34 @@ module PuppetX
         def self.fuzzy_compare(existing, intended)
           normalized_is = existing.swagger_symbolize_keys.fixnumify
           normalized_should = intended.swagger_symbolize_keys.fixnumify
-          if normalized_is.respond_to? :all? and normalized_is.all? { |k,v| v.class == String }
-            diff = normalized_is.merge(normalized_should)
-            diff == normalized_is
-          elsif normalized_is == normalized_should
-            true
-          else
-            tests = test_complex_structure(normalized_should, normalized_is)
-            tests.flatten.compact.all?
-          end
+          do_compare(normalized_should, normalized_is)
         end
-        def self.test_complex_structure(normalized_should, normalized_is)
-          normalized_should.keys.collect do |key|
-            klass = normalized_is[key].class
-            if [String, Fixnum].include? klass
-              normalized_is[key].to_s == normalized_should[key].to_s
-            elsif klass == Array
-              normalized_is[key].collect do |is_value|
-                normalized_should[key].collect do |should_value|
-                  diff = if is_value.class == Hash
-                    is_value.merge(should_value)
-                  else
-                    should_value
-                  end
-                  diff == is_value
+
+        private
+        def self.do_compare(normalized_should, normalized_is)
+          klass = normalized_should.class
+          if [String, Fixnum, TrueClass, FalseClass, NilClass].include? klass
+            normalized_should.to_s == normalized_is.to_s
+          elsif klass == Array
+            if normalized_is.class != Array || normalized_should.length != normalized_is.length
+              false
+            else
+              # We want to check that both arrays have the same elements regardless of their order
+              tests = normalized_is.collect do |is_value|
+                normalized_should.lazy.reduce(false) do |m, should_value|
+                  m || do_compare(should_value, is_value)
                 end
               end
-            elsif klass == Hash
-              diff = normalized_is[key].merge(normalized_should[key])
-              if diff == normalized_is[key]
-                true
-              else
-                normalized_should[key].keys.collect do |inner_key|
-                  test_complex_structure(normalized_should[key][inner_key], normalized_is[key][inner_key])
-                end
-              end
+              tests.flatten.compact.all?
             end
+          elsif klass == Hash
+            if normalized_is.class != Hash
+              false
+            else
+              normalized_should.lazy.all? { |key, should_value| do_compare(should_value, normalized_is[key]) }
+            end
+          else
+           raise "Don't know how to compare object '#{normalized_should}' of class #{klass}"
           end
         end
       end


### PR DESCRIPTION
Along with comparing arrays independently of their orders from PR #5, this code makes sure arrays are correctly compared elements by elements.

This also includes support for comparing empty values:
   `{:resources => { :requests=> {:cpu => "1"}}}`
    comparing with
   ` {:resources => nil}`