### PR TITLE
Handle array properties and assorted fixes

### DIFF
--- a/lib/puppet-swagger-generator/files/swagger/provider.rb
+++ b/lib/puppet-swagger-generator/files/swagger/provider.rb
@@ -35,7 +35,7 @@ module PuppetX
         end
 
         def exists?
-          Puppet.info("Checking if #{name} exists")
+          Puppet.debug("Checking if #{resource.type}[#{name}] exists")
           @property_hash[:ensure] and @property_hash[:ensure] != :absent
         end
 

--- a/lib/puppet-swagger-generator/templates/type.erb
+++ b/lib/puppet-swagger-generator/templates/type.erb
@@ -34,7 +34,7 @@ Puppet::Type.newtype(:<%= namespace %>_<%= name %>) do
   <% model['properties'].each do |property_name, details| %>
     <% unless exclusions.include? property_name %>
       newproperty(:<%= property_name.swagger_to_snake_case %>) do
-        <% if model['description'] %>
+        <% if details['description'] %>
         desc "<%= details['description'].gsub('"', "'") %>"
         <% end %>
         def insync?(is)

--- a/lib/puppet-swagger-generator/templates/type.erb
+++ b/lib/puppet-swagger-generator/templates/type.erb
@@ -33,7 +33,11 @@ Puppet::Type.newtype(:<%= namespace %>_<%= name %>) do
   end
   <% model['properties'].each do |property_name, details| %>
     <% unless exclusions.include? property_name %>
+      <% if details['type'] == 'array' %>
+      newproperty(:<%= property_name.swagger_to_snake_case %>, :array_matching => :all) do
+      <% else %>
       newproperty(:<%= property_name.swagger_to_snake_case %>) do
+      <% end %>
         <% if details['description'] %>
         desc "<%= details['description'].gsub('"', "'") %>"
         <% end %>

--- a/lib/puppet-swagger-generator/templates/type.erb
+++ b/lib/puppet-swagger-generator/templates/type.erb
@@ -16,7 +16,7 @@ Puppet::Type.newtype(:<%= namespace %>_<%= name %>) do
   validate do
     required_properties = [
     <% model['required'].each do |property| %>
-      <%= property.swagger_to_snake_case.to_sym %>,
+      :<%= property.swagger_to_snake_case.to_sym %>,
     <% end %>
     ]
     required_properties.each do |property|


### PR DESCRIPTION
This contains a set of fix from @teintuc to the swagger template so that:
* description appears
* required properties are generated correctly
* array properties are handled as arrays by puppet

